### PR TITLE
utils: more normalization of arXiv categories

### DIFF
--- a/inspire_dojson/utils/arxiv.py
+++ b/inspire_dojson/utils/arxiv.py
@@ -219,8 +219,9 @@ ARXIV_TO_INSPIRE_CATEGORY_MAPPING = {
 def normalize_arxiv_category(category):
     """Normalize arXiv category to be schema compliant.
 
-    This properly capitalizes the category and, if it is obsolete, converts it
-    to its current equivalent.
+    This properly capitalizes the category and replaces the dash by a dot if
+    needed. If the category is obsolete, it also gets converted it to its
+    current equivalent.
 
     Example:
         >>> normalize_arxiv_category('funct-an')
@@ -228,7 +229,8 @@ def normalize_arxiv_category(category):
     """
     category = _NEW_CATEGORIES.get(category.lower(), category)
     for valid_category in valid_arxiv_categories():
-        if category.lower() == valid_category.lower():
+        if (category.lower() == valid_category.lower() or
+                category.lower().replace('-', '.') == valid_category.lower()):
             return valid_category
     return category  # XXX: will fail validation and be logged
 

--- a/tests/unit/test_utils_arxiv.py
+++ b/tests/unit/test_utils_arxiv.py
@@ -81,3 +81,10 @@ def test_normalize_arxiv_category_returns_existing_category_for_wrong_caps():
     result = normalize_arxiv_category('HeP-Th')
 
     assert expected == result
+
+
+def test_normalize_arxiv_category_returns_existing_category_when_dot_is_dash():
+    expected = 'math.FA'
+    result = normalize_arxiv_category('math-fa')
+
+    assert expected == result


### PR DESCRIPTION
Dashes instead of dots in arXiv categories is a common cause of doJSON failures (~2K records).