### PR TITLE
setup: bump inspire-schemas to version ~43.0

### DIFF
--- a/inspire_dojson/hep/__init__.py
+++ b/inspire_dojson/hep/__init__.py
@@ -34,5 +34,6 @@ from .rules import (  # noqa
     bd6xx,
     bd7xx,
     bd9xx,
+    bdFFT,
 )
 from .model import hep, hep2marc  # noqa

--- a/inspire_dojson/hep/rules/bdFFT.py
+++ b/inspire_dojson/hep/rules/bdFFT.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""DoJSON rules for FFT."""
+
+from __future__ import absolute_import, division, print_function
+
+from datetime import datetime
+
+from dojson import utils
+
+from ..model import hep, hep2marc
+from ...utils import absolute_url, force_single_element
+from ...utils.helpers import force_list, maybe_int
+
+
+@hep.over('_fft', '^FFT[^%][^%]')
+@utils.for_each_value
+def _fft(self, key, value):
+    def _get_creation_datetime(value):
+        dt = datetime.strptime(value.get('s'), '%Y-%m-%d %H:%M:%S')
+        return dt.isoformat()
+
+    is_context = value.get('f', '').endswith('context')
+    if is_context:
+        return
+
+    return {
+        'creation_datetime': _get_creation_datetime(value),
+        'description': value.get('d'),
+        'filename': value.get('n'),
+        'flags': force_list(value.get('o')),
+        'format': value.get('f'),
+        'path': value.get('a'),
+        'status': value.get('z'),
+        'type': value.get('t'),
+        'version': maybe_int(value.get('v')),
+    }
+
+
+@hep2marc.over('FFT', '^documents')
+@utils.for_each_value
+def documents2marc(self, key, value):
+    def _get_type(value):
+        doctype = value.get('source', 'INSPIRE-PUBLIC')
+        if doctype == 'submitter':
+            return 'INSPIRE-PUBLIC'
+        return doctype
+    return {
+        'd': value.get('description'),
+        'a': absolute_url(value.get('url')),
+        't': _get_type(value),
+        'o': 'HIDDEN' if value.get('hidden') else None,
+    }
+
+
+@hep2marc.over('FFT', '^figures')
+def figures2marc(self, key, values):
+    fft = self.setdefault('FFT', [])
+    for index, value in enumerate(values):
+        fft.append({
+            'd': '{:05d} {}'.format(index, value.get('caption')),
+            'a': absolute_url(value.get('url')),
+            't': 'Plot',
+        })
+
+    return fft

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     'IDUtils~=0.0,>=0.2.4',
     'autosemver~=0.0,>=0.5.1',
     'dojson~=1.0,>=1.3.1',
-    'inspire-schemas~=42.0,>=42.0.0',
+    'inspire-schemas~=43.0,>=43.0.0',
     'langdetect~=1.0,>=1.0.7',
     'pycountry~=17.0,>=17.5.4',
 ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,6 +28,7 @@ from flask import Flask
 
 CONFIG = {
     'SERVER_NAME': 'localhost:5000',
+    'LEGACY_BASE_URL': 'http://inspirehep.net',
 }
 
 

--- a/tests/unit/test_dojson_common.py
+++ b/tests/unit/test_dojson_common.py
@@ -444,73 +444,6 @@ def test_inspire_categories_from_65017a_2_discards_arxiv():
     assert 'inspire_categories' not in result
 
 
-def test_fft_from_FFT():
-    schema = load_schema('hep')
-    subschema = schema['properties']['_fft']
-
-    snippet = (
-        '<datafield tag="FFT" ind1=" " ind2=" ">'
-        '  <subfield code="a">/opt/cds-invenio/var/data/files/g122/2457396/content.xml;1</subfield>'
-        '  <subfield code="d"/>'
-        '  <subfield code="f">.xml</subfield>'
-        '  <subfield code="n">0029558261904692</subfield>'
-        '  <subfield code="r"/>'
-        '  <subfield code="s">2016-04-01 15:14:38</subfield>'
-        '  <subfield code="t">Main</subfield>'
-        '  <subfield code="v">1</subfield>'
-        '  <subfield code="z"/>'
-        '  <subfield code="o">HIDDEN</subfield>'
-        '</datafield>'
-    )  # record/4328/export/xme
-
-    expected = [
-        {
-            'creation_datetime': '2016-04-01T15:14:38',
-            'filename': '0029558261904692',
-            'flags': [
-                'HIDDEN',
-            ],
-            'format': '.xml',
-            'path': '/opt/cds-invenio/var/data/files/g122/2457396/content.xml;1',
-            'type': 'Main',
-            'version': 1,
-        },
-    ]
-    result = hep.do(create_record(snippet))
-
-    assert validate(result['_fft'], subschema) is None
-    assert expected == result['_fft']
-
-    expected = [
-        {
-            'a': '/opt/cds-invenio/var/data/files/g122/2457396/content.xml;1',
-            'f': '.xml',
-            'n': '0029558261904692',
-            'o': [
-                'HIDDEN',
-            ],
-            's': '2016-04-01 15:14:38',
-            't': 'Main',
-            'v': 1,
-        },
-    ]
-    result = hep2marc.do(result)
-
-    assert expected == result['FFT']
-
-
-def test_fft_from_FFT_percent_percent():
-    snippet = (
-        '<datafield tag="FFT" ind1="%" ind2="%">'
-        '  <subfield code="a">/opt/cds-invenio/var/tmp-shared/apsharvest_unzip_5dGfY5/articlebag-10-1103-PhysRevD-87-083514-apsxml/data/PhysRevD.87.083514/fulltext.xml</subfield>'
-        '  <subfield code="o">HIDDEN</subfield>'
-        '  <subfield code="t">APS</subfield>'
-        '</datafield>'
-    )  # record/1094156
-
-    assert '_fft' not in hep.do(create_record(snippet))
-
-
 def test_urls_from_8564_u_y():
     schema = load_schema('hep')
     subschema = schema['properties']['urls']
@@ -542,6 +475,33 @@ def test_urls_from_8564_u_y():
     result = hep2marc.do(result)
 
     assert expected == result['8564']
+
+
+def test_urls_from_8564_ignores_internal_links():
+    snippet = (
+        '<datafield tag="856" ind1="4" ind2=" ">'
+        '  <subfield code="s">1506142</subfield>'
+        '  <subfield code="u">http://inspirehep.net/record/1610503/files/arXiv:1707.05770.pdf</subfield>'
+        '</datafield>'
+    )  # record/1610503/export/xme
+
+    result = hep.do(create_record(snippet))
+
+    assert 'urls' not in result
+
+
+def test_urls_from_8564_ignores_internal_links_https():
+    snippet = (
+        '<datafield tag="856" ind1="4" ind2=" ">'
+        '  <subfield code="s">2392681</subfield>'
+        '  <subfield code="u">https://inspirehep.net/record/1508108/files/fermilab-pub-16-617-cms.pdf</subfield>'
+        '  <subfield code="y">Fulltext</subfield>'
+        '</datafield>'
+    )  # record/1508036/export/xme
+
+    result = hep.do(create_record(snippet))
+
+    assert 'urls' not in result
 
 
 def test_urls_from_8564_s_u_ignores_s():

--- a/tests/unit/test_dojson_hep_bdFFT.py
+++ b/tests/unit/test_dojson_hep_bdFFT.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from dojson.contrib.marc21.utils import create_record
+
+from inspire_schemas.utils import load_schema
+
+from inspire_dojson.hep import hep, hep2marc
+from inspire_dojson.utils import validate
+
+
+def test_fft_from_FFT():
+    schema = load_schema('hep')
+    subschema = schema['properties']['_fft']
+
+    snippet = (
+        '<datafield tag="FFT" ind1=" " ind2=" ">'
+        '  <subfield code="a">/opt/cds-invenio/var/data/files/g122/2457396/content.xml;1</subfield>'
+        '  <subfield code="d"/>'
+        '  <subfield code="f">.xml</subfield>'
+        '  <subfield code="n">0029558261904692</subfield>'
+        '  <subfield code="r"/>'
+        '  <subfield code="s">2016-04-01 15:14:38</subfield>'
+        '  <subfield code="t">Main</subfield>'
+        '  <subfield code="v">1</subfield>'
+        '  <subfield code="z"/>'
+        '  <subfield code="o">HIDDEN</subfield>'
+        '</datafield>'
+    )  # record/4328/export/xme
+
+    expected = [
+        {
+            'creation_datetime': '2016-04-01T15:14:38',
+            'filename': '0029558261904692',
+            'flags': [
+                'HIDDEN',
+            ],
+            'format': '.xml',
+            'path': '/opt/cds-invenio/var/data/files/g122/2457396/content.xml;1',
+            'type': 'Main',
+            'version': 1,
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['_fft'], subschema) is None
+    assert expected == result['_fft']
+
+    result = hep2marc.do(result)
+
+    assert result is None
+
+
+def test_fft_from_FFT_percent_percent():
+    snippet = (
+        '<datafield tag="FFT" ind1="%" ind2="%">'
+        '  <subfield code="a">/opt/cds-invenio/var/tmp-shared/apsharvest_unzip_5dGfY5/articlebag-10-1103-PhysRevD-87-083514-apsxml/data/PhysRevD.87.083514/fulltext.xml</subfield>'
+        '  <subfield code="o">HIDDEN</subfield>'
+        '  <subfield code="t">APS</subfield>'
+        '</datafield>'
+    )  # record/1094156
+
+    assert '_fft' not in hep.do(create_record(snippet))
+
+
+def test_fft_from_FFT_ignores_context():
+    snippet = (
+        '<datafield tag="FFT" ind1=" " ind2=" ">'
+        '  <subfield code="a">/opt/cds-invenio/var/data/files/g148/2964970/content.png;context;1</subfield>'
+        '  <subfield code="d"/>'
+        '  <subfield code="f">.png;context</subfield>'
+        '  <subfield code="n">TNR</subfield>'
+        '  <subfield code="r"/>'
+        '  <subfield code="s">2017-07-19 09:29:27</subfield>'
+        '  <subfield code="t">Main</subfield>'
+        '  <subfield code="v">1</subfield><subfield code="z"/>'
+        '  <subfield code="o">HIDDEN</subfield>'
+        '</datafield>'
+    )  # record/1610503/export/xme
+
+    result = hep.do(create_record(snippet))
+
+    assert '_fft' not in result
+
+
+def test_documents_to_FFT():
+    schema = load_schema('hep')
+    subschema = schema['properties']['documents']
+
+    snippet = {
+        'documents': [
+            {
+                'key': 'some_document.pdf',
+                'description': 'Thesis fulltext',
+                'hidden': True,
+                'fulltext': True,
+                'material': 'publication',
+                'url': '/files/1234-1234-1234-1234/some_document.pdf',
+                'original_url': 'http://example.com/some_document.pdf',
+                'source': 'submitter',
+            }
+        ]
+    }
+    # XXX record invented
+
+    expected = [
+        {
+            'a': 'http://localhost:5000/files/1234-1234-1234-1234/some_document.pdf',
+            'd': 'Thesis fulltext',
+            't': 'INSPIRE-PUBLIC',
+            'o': 'HIDDEN',
+        }
+    ]
+
+    assert validate(snippet['documents'], subschema) is None
+
+    result = hep2marc.do(snippet)
+
+    assert expected == result['FFT']
+
+
+def test_figures_to_FFT():
+    schema = load_schema('hep')
+    subschema = schema['properties']['figures']
+
+    snippet = {
+        'figures': [
+            {
+                'key': 'some_figure.png',
+                'caption': 'This figure illustrates something',
+                'material': 'preprint',
+                'url': '/files/1234-1234-1234-1234/some_figure.png',
+                'source': 'arxiv',
+            }
+        ]
+    }
+    # XXX record invented
+
+    expected = [
+        {
+            'a': 'http://localhost:5000/files/1234-1234-1234-1234/some_figure.png',
+            'd': '00000 This figure illustrates something',
+            't': 'Plot',
+        }
+    ]
+
+    assert validate(snippet['figures'], subschema) is None
+
+    result = hep2marc.do(snippet)
+
+    assert expected == result['FFT']

--- a/tests/unit/test_dojson_utils.py
+++ b/tests/unit/test_dojson_utils.py
@@ -28,6 +28,7 @@ from mock import patch
 from inspire_schemas.utils import load_schema
 
 from inspire_dojson.utils import (
+    absolute_url,
     normalize_rank,
     force_single_element,
     get_recid_from_ref,
@@ -94,6 +95,46 @@ def test_force_single_element_returns_element_when_not_a_list():
 
 def test_force_single_element_returns_none_on_empty_list():
     assert force_single_element([]) is None
+
+
+def test_absolute_url_with_empty_server_name():
+    config = {}
+
+    with patch.dict(current_app.config, config, clear=True):
+        expected = 'http://inspirehep.net/foo'
+        result = absolute_url('foo')
+
+        assert expected == result
+
+
+def test_absolute_url_with_server_name_localhost():
+    config = {'SERVER_NAME': 'localhost:5000'}
+
+    with patch.dict(current_app.config, config):
+        expected = 'http://localhost:5000/foo'
+        result = absolute_url('foo')
+
+        assert expected == result
+
+
+def test_absolute_url_with_http_server_name():
+    config = {'SERVER_NAME': 'http://example.com'}
+
+    with patch.dict(current_app.config, config):
+        expected = 'http://example.com/foo'
+        result = absolute_url('foo')
+
+        assert expected == result
+
+
+def test_absolute_url_with_https_server_name():
+    config = {'SERVER_NAME': 'https://example.com'}
+
+    with patch.dict(current_app.config, config):
+        expected = 'https://example.com/foo'
+        result = absolute_url('foo')
+
+        assert expected == result
 
 
 def test_get_record_ref_with_empty_server_name():


### PR DESCRIPTION
This changes how files (figures and documents) are handled:

* For MARC->JSON conversion, `_fft` is still being written as doJSON
does not have enough information to actually attach the files to the
record, but `urls` now only contains links to external resources.

* In the other direction, `figures` and `documents` are used to prepare
an FFT on legacy.