### PR TITLE
hep: handle special collections correctly

### DIFF
--- a/inspire_dojson/hep/model.py
+++ b/inspire_dojson/hep/model.py
@@ -25,7 +25,7 @@
 from __future__ import absolute_import, division, print_function
 
 
-from ..model import FilterOverdo, add_schema, add_collection, clean_record
+from ..model import FilterOverdo, add_schema, clean_record
 from ..utils.arxiv import normalize_arxiv_category, classify_field
 from ..utils.helpers import force_list
 from ..utils.record import get_value
@@ -68,16 +68,8 @@ def ensure_document_type(record, blob):
     return record
 
 
-def ensure_hep(record, blob):
-    if not blob.get('special_collections'):
-        record.setdefault('980', []).append({'a': 'HEP'})
-
-    return record
-
-
 hep_filters = [
     add_schema('hep.json'),
-    add_collection('Literature'),
     add_arxiv_categories,
     add_inspire_categories,
     ensure_document_type,
@@ -85,7 +77,6 @@ hep_filters = [
 ]
 
 hep2marc_filters = [
-    ensure_hep,
     clean_record,
 ]
 

--- a/inspire_dojson/hep/rules/bd9xx.py
+++ b/inspire_dojson/hep/rules/bd9xx.py
@@ -103,6 +103,8 @@ def document_type(self, key, value):
 
         if normalized_a_value == 'arxiv':
             continue  # XXX: ignored.
+        elif normalized_a_value == 'hep':
+            self.setdefault('_collections', []).append('Literature')
         elif normalized_a_value == 'citeable':
             self['citeable'] = True
         elif normalized_a_value == 'core':
@@ -179,6 +181,13 @@ def withdrawn2marc(self, key, value):
 @utils.for_each_value
 def publication_type2marc(self, key, value):
     return {'a': value}
+
+
+@hep2marc.over('980', '^_collections$')
+@utils.for_each_value
+def _collections2marc(self, key, value):
+    if value == 'Literature':
+        return {'a': 'HEP'}
 
 
 @hep2marc.over('980', '^special_collections$')

--- a/tests/unit/test_dojson_hep_bd6xx.py
+++ b/tests/unit/test_dojson_hep_bd6xx.py
@@ -217,9 +217,7 @@ def test_keywords2marc_does_not_export_magpie_keywords():
 
     result = hep2marc.do(record)
 
-    assert '084' not in result
-    assert '6531' not in result
-    assert '695' not in result
+    assert result is None
 
 
 def test_accelerator_experiments_from_693__a_e():

--- a/tests/unit/test_dojson_hep_bd9xx.py
+++ b/tests/unit/test_dojson_hep_bd9xx.py
@@ -130,7 +130,6 @@ def test_citeable_from_980__a_citeable():
 
     expected = [
         {'a': 'Citeable'},
-        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -155,7 +154,6 @@ def test_core_from_980__a_core():
 
     expected = [
         {'a': 'CORE'},
-        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -180,7 +178,6 @@ def test_core_from_980__a_noncore():
 
     expected = [
         {'a': 'NONCORE'},
-        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -205,6 +202,29 @@ def test_deleted_from_980__c():
 
     expected = [
         {'c': 'DELETED'},
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['980']
+
+
+def test_collections_from_980__a():
+    schema = load_schema('hep')
+    subschema = schema['properties']['_collections']
+
+    snippet = (
+        '<datafield tag="980" ind1=" " ind2=" ">'
+        '  <subfield code="a">HEP</subfield>'
+        '</datafield>'
+    )  # record/1610892
+
+    expected = ['Literature']
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['_collections'], subschema) is None
+    assert expected == result['_collections']
+
+    expected = [
         {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
@@ -229,6 +249,7 @@ def test_special_collections_from_980__a():
 
     assert validate(result['special_collections'], subschema) is None
     assert expected == result['special_collections']
+    assert '_collections' not in result
 
     expected = [
         {'a': 'HALHIDDEN'},
@@ -255,6 +276,7 @@ def test_special_collections_from_980__a_babar_analysis_document():
 
     assert validate(result['special_collections'], subschema) is None
     assert expected == result['special_collections']
+    assert '_collections' not in result
 
     expected = [
         {'a': 'BABAR-AnalysisDocument'},
@@ -262,6 +284,42 @@ def test_special_collections_from_980__a_babar_analysis_document():
     result = hep2marc.do(result)
 
     assert expected == result['980']
+
+
+def test_collections_and_special_collections_from_980__a():
+    schema = load_schema('hep')
+    subschema_collections = schema['properties']['_collections']
+    subschema_special = schema['properties']['special_collections']
+
+    snippet = (
+        '<record>'
+        '  <datafield tag="980" ind1=" " ind2=" ">'
+        '    <subfield code="a">D0-PRELIMINARY-NOTE</subfield>'
+        '  </datafield>'
+        '  <datafield tag="980" ind1=" " ind2=" ">'
+        '    <subfield code="a">HEP</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1201407
+
+    expected = {
+        '_collections': ['Literature'],
+        'special_collections': ['D0-PRELIMINARY-NOTE'],
+    }
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['_collections'], subschema_collections) is None
+    assert validate(result['special_collections'], subschema_special) is None
+    assert expected['_collections'] == result['_collections']
+    assert expected['special_collections'] == result['special_collections']
+
+    expected = [
+        {'a': 'HEP'},
+        {'a': 'D0-PRELIMINARY-NOTE'},
+    ]
+    result = hep2marc.do(result)
+
+    assert sorted(expected) == sorted(result['980'])
 
 
 def test_refereed_from_980__a_published():
@@ -282,7 +340,6 @@ def test_refereed_from_980__a_published():
 
     expected = [
         {'a': 'Published'},
-        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -305,12 +362,9 @@ def test_document_type_defaults_to_article():
     assert validate(result['document_type'], subschema) is None
     assert expected == result['document_type']
 
-    expected = [
-        {'a': 'HEP'},
-    ]
     result = hep2marc.do(result)
 
-    assert expected == result['980']
+    assert result is None
 
 
 def test_document_type_from_980__a():
@@ -333,7 +387,6 @@ def test_document_type_from_980__a():
 
     expected = [
         {'a': 'Book'},
-        {'a': 'HEP'}
     ]
     result = hep2marc.do(result)
 
@@ -360,7 +413,6 @@ def test_document_type_from_980__a_handles_conference_paper():
 
     expected = [
         {'a': 'ConferencePaper'},
-        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -387,7 +439,6 @@ def test_document_type_from_980__a_handles_activity_report():
 
     expected = [
         {'a': 'ActivityReport'},
-        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -414,7 +465,6 @@ def test_publication_type_from_980__a():
 
     expected = [
         {'a': 'review'},
-        {'a': 'HEP'}
     ]
     result = hep2marc.do(result)
 
@@ -439,7 +489,6 @@ def test_withdrawn_from_980__a_withdrawn():
 
     expected = [
         {'a': 'Withdrawn'},
-        {'a': 'HEP'}
     ]
     result = hep2marc.do(result)
 


### PR DESCRIPTION
Only records with `980__a:HEP` now get `Literature` as a `_collection`,
records not in HEP don't, in order to properly hide the records not
belonging to the main collection. This requires assigning collections
for the `hep` model based on the contents of the records, instead of
doing it in a filter. Fixes #36.

Signed-off-by: Micha Moskovic <michamos@gmail.com>