### PR TITLE
hep: readd ensure_hep

### DIFF
--- a/inspire_dojson/hep/model.py
+++ b/inspire_dojson/hep/model.py
@@ -24,7 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 from ..model import FilterOverdo, add_schema, clean_record
 from ..utils.arxiv import normalize_arxiv_category, classify_field
 from ..utils.helpers import force_list
@@ -68,6 +67,13 @@ def ensure_document_type(record, blob):
     return record
 
 
+def ensure_hep(record, blob):
+    if not blob.get('special_collections'):
+        record.setdefault('980', []).append({'a': 'HEP'})
+
+    return record
+
+
 hep_filters = [
     add_schema('hep.json'),
     add_arxiv_categories,
@@ -77,6 +83,7 @@ hep_filters = [
 ]
 
 hep2marc_filters = [
+    ensure_hep,
     clean_record,
 ]
 

--- a/tests/unit/test_dojson_hep_bd6xx.py
+++ b/tests/unit/test_dojson_hep_bd6xx.py
@@ -217,7 +217,9 @@ def test_keywords2marc_does_not_export_magpie_keywords():
 
     result = hep2marc.do(record)
 
-    assert result is None
+    assert '084' not in result
+    assert '6531' not in result
+    assert '695' not in result
 
 
 def test_accelerator_experiments_from_693__a_e():

--- a/tests/unit/test_dojson_hep_bd9xx.py
+++ b/tests/unit/test_dojson_hep_bd9xx.py
@@ -130,6 +130,7 @@ def test_citeable_from_980__a_citeable():
 
     expected = [
         {'a': 'Citeable'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -154,6 +155,7 @@ def test_core_from_980__a_core():
 
     expected = [
         {'a': 'CORE'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -178,6 +180,7 @@ def test_core_from_980__a_noncore():
 
     expected = [
         {'a': 'NONCORE'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -202,6 +205,7 @@ def test_deleted_from_980__c():
 
     expected = [
         {'c': 'DELETED'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -340,6 +344,7 @@ def test_refereed_from_980__a_published():
 
     expected = [
         {'a': 'Published'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -362,9 +367,12 @@ def test_document_type_defaults_to_article():
     assert validate(result['document_type'], subschema) is None
     assert expected == result['document_type']
 
+    expected = [
+        {'a': 'HEP'},
+    ]
     result = hep2marc.do(result)
 
-    assert result is None
+    assert expected == result['980']
 
 
 def test_document_type_from_980__a():
@@ -387,6 +395,7 @@ def test_document_type_from_980__a():
 
     expected = [
         {'a': 'Book'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -413,6 +422,7 @@ def test_document_type_from_980__a_handles_conference_paper():
 
     expected = [
         {'a': 'ConferencePaper'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -439,6 +449,7 @@ def test_document_type_from_980__a_handles_activity_report():
 
     expected = [
         {'a': 'ActivityReport'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -465,6 +476,7 @@ def test_publication_type_from_980__a():
 
     expected = [
         {'a': 'review'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 
@@ -489,6 +501,7 @@ def test_withdrawn_from_980__a_withdrawn():
 
     expected = [
         {'a': 'Withdrawn'},
+        {'a': 'HEP'},
     ]
     result = hep2marc.do(result)
 

--- a/tests/unit/test_dojson_hep_bdFFT.py
+++ b/tests/unit/test_dojson_hep_bdFFT.py
@@ -69,7 +69,7 @@ def test_fft_from_FFT():
 
     result = hep2marc.do(result)
 
-    assert result is None
+    assert 'FFT' not in result
 
 
 def test_fft_from_FFT_percent_percent():


### PR DESCRIPTION
Commit 0029b23 forgot to consider that records that we're ingesting from
forms don't yet have the `_collections` key set with the proper value,
so we won't get `980__a:HEP` when sending the record to Legacy.

Note that the existing tests ensure that records that belong to a
special collection only don't become part of the HEP collection, while
records that belonged to both continue belonging to both.

CC: @jmartinm, who reported the bug.