### PR TITLE
hep: readd _fft2marc

### DIFF
--- a/inspire_dojson/hep/rules/bdFFT.py
+++ b/inspire_dojson/hep/rules/bdFFT.py
@@ -57,6 +57,27 @@ def _fft(self, key, value):
     }
 
 
+@hep2marc.over('FFT', '^_fft$')
+@utils.for_each_value
+def _fft2marc(self, key, value):
+    def _get_s(value):
+        if value.get('creation_datetime'):
+            dt = datetime.strptime(value['creation_datetime'], '%Y-%m-%dT%H:%M:%S')
+            return dt.strftime('%Y-%m-%d %H:%M:%S')
+
+    return {
+        'a': value.get('path'),
+        'd': value.get('description'),
+        'f': value.get('format'),
+        'n': value.get('filename'),
+        'o': value.get('flags'),
+        's': _get_s(value),
+        't': value.get('type'),
+        'v': value.get('version'),
+        'z': value.get('status'),
+    }
+
+
 @hep2marc.over('FFT', '^documents')
 @utils.for_each_value
 def documents2marc(self, key, value):

--- a/tests/unit/test_dojson_hep_bdFFT.py
+++ b/tests/unit/test_dojson_hep_bdFFT.py
@@ -67,9 +67,22 @@ def test_fft_from_FFT():
     assert validate(result['_fft'], subschema) is None
     assert expected == result['_fft']
 
+    expected = [
+        {
+            'a': '/opt/cds-invenio/var/data/files/g122/2457396/content.xml;1',
+            'f': '.xml',
+            'n': '0029558261904692',
+            'o': [
+                'HIDDEN',
+            ],
+            's': '2016-04-01 15:14:38',
+            't': 'Main',
+            'v': 1,
+        },
+    ]
     result = hep2marc.do(result)
 
-    assert 'FFT' not in result
+    assert expected == result['FFT']
 
 
 def test_fft_from_FFT_percent_percent():


### PR DESCRIPTION
Commit 5cb6253 forgot to consider that records we ingest through forms
have the `_fft` key populated, from which an `FFT` field is generated
on legacy.

In the future the form will populate the `documents` key, and this
commit will be reverted.