### PR TITLE
utils: convert to unicode earlier

### DIFF
--- a/inspire_dojson/utils/text.py
+++ b/inspire_dojson/utils/text.py
@@ -50,6 +50,9 @@ def encode_for_xml(text, wash=False, xml_version='1.0', quote=False):
     :param text: text to encode
     :return: an encoded text
     """
+    if not isinstance(text, six.text_type):
+        text = six.text_type(text)
+
     text = text.replace('&', '&amp;')
     text = text.replace('<', '&lt;')
     if quote:
@@ -73,9 +76,6 @@ def wash_for_xml(text, xml_version='1.0'):
     :param xml_version: version of the XML for which we wash the
         input. Value for this parameter can be '1.0' or '1.1'
     """
-    if not isinstance(text, six.text_type):
-        text = six.text_type(text.decode('utf8', 'ignore'))
-
     if xml_version == '1.0':
         return RE_ALLOWED_XML_1_0_CHARS.sub('', text)
     else:

--- a/tests/unit/test_dojson_utils.py
+++ b/tests/unit/test_dojson_utils.py
@@ -265,6 +265,25 @@ def test_legacy_export_as_marc_handles_unicode():
     assert expected == result
 
 
+def test_legacy_export_as_marc_handles_numbers():
+    record = {
+        '773': [
+            {'y': 1975},
+        ],
+    }
+
+    expected = (
+        '<record>\n'
+        '    <datafield tag="773" ind1="" ind2="">\n'
+        '        <subfield code="y">1975</subfield>\n'
+        '    </datafield>\n'
+        '</record>\n'
+    )
+    result = legacy_export_as_marc(record)
+
+    assert expected == result
+
+
 def test_dedupe_all_lists():
     obj = {'l0': list(range(10)) + list(range(10)),
            'o1': [{'foo': 'bar'}] * 10,


### PR DESCRIPTION
Commit da1bd40 removed several unicode encodings and decodings, but
put the last remaining one too late, after the variable had already
been treated as a string (by calling `replace` on it).