### PR TITLE
hep: handle report_numbers with arXiv source

### DIFF
--- a/inspire_dojson/hep/rules/bd0xx.py
+++ b/inspire_dojson/hep/rules/bd0xx.py
@@ -286,6 +286,11 @@ def arxiv_eprints(self, key, value):
     def _is_hidden_report_number(other_id, source):
         return other_id
 
+    def _get_clean_source(source):
+        if source == 'arXiv:reportnumber':
+            return 'arXiv'
+        return source
+
     arxiv_eprints = self.get('arxiv_eprints', [])
     report_numbers = self.get('report_numbers', [])
 
@@ -305,12 +310,12 @@ def arxiv_eprints(self, key, value):
         elif _is_hidden_report_number(other_id, source):
             report_numbers.append({
                 'hidden': True,
-                'source': source,
+                'source': _get_clean_source(source),
                 'value': other_id,
             })
         else:
             report_numbers.append({
-                'source': source,
+                'source': _get_clean_source(source),
                 'value': id_,
             })
 
@@ -356,14 +361,21 @@ def arxiv_eprints2marc(self, key, value):
 @hep2marc.over('037', '^report_numbers$')
 @utils.for_each_value
 def report_numbers2marc(self, key, value):
+    def _get_mangled_source(source):
+        if source == 'arXiv':
+            return 'arXiv:reportnumber'
+        return source
+
+    source = _get_mangled_source(value.get('source'))
+
     if value.get('hidden'):
         return {
-            '9': value.get('source'),
+            '9': source,
             'z': value.get('value'),
         }
 
     return {
-        '9': value.get('source'),
+        '9': source,
         'a': value.get('value'),
     }
 

--- a/tests/test_hep_bd0xx.py
+++ b/tests/test_hep_bd0xx.py
@@ -795,6 +795,40 @@ def test_report_numbers_from_037__z_9():
     assert expected == result['037']
 
 
+def test_report_numbers_from_037__a_9_arXiv_reportnumber():
+    schema = load_schema('hep')
+    subschema = schema['properties']['report_numbers']
+
+    snippet = (
+        '<datafield tag="037" ind1=" " ind2=" ">'
+        '  <subfield code="9">arXiv:reportnumber</subfield>'
+        '  <subfield code="a">LIGO-P1500247</subfield>'
+        '</datafield>'
+    )  # record/1618037
+
+    expected = [
+        {
+            'source': 'arXiv',
+            'value': 'LIGO-P1500247',
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['report_numbers'], subschema) is None
+    assert expected == result['report_numbers']
+
+    expected = [
+        {
+            '9': 'arXiv:reportnumber',
+            'a': 'LIGO-P1500247',
+        },
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['037']
+    assert '035' not in result
+
+
 def test_arxiv_eprints_from_037__a_c_9_and_multiple_65017_a_2():
     schema = load_schema('hep')
     subschema = schema['properties']['arxiv_eprints']


### PR DESCRIPTION
Previously, `report_numbers` with `source=arXiv` were converted in
`hep2marc` to `037` with `9=arXiv`. This was interpreted on legacy as an
arXiv eprint number, as opposed to an ordinary report number with source
arXiv. This introduces a workaround, converting the `source=arXiv` to
`9=arXiv:reportnumber` instead and doing the opposite in the other
direction.

Signed-off-by: Micha Moskovic <michamos@gmail.com>