### PR TITLE
hep: do the work of invenio-collections in DoJSON

### DIFF
--- a/inspire_dojson/hep/model.py
+++ b/inspire_dojson/hep/model.py
@@ -31,6 +31,27 @@ from ..utils.arxiv import normalize_arxiv_category, classify_field
 from ..utils.helpers import force_list
 
 
+SPECIAL_COLLECTIONS_MAP = {
+    'BABAR-ANALYSIS-DOCUMENT': 'BABAR Analysis Documents',
+    'BABAR-INTERNAL-BAIS': 'BABAR Internal BAIS',
+    'BABAR-INTERNAL-NOTE': 'BABAR Internal Notes',
+    'CDF-INTERNAL-NOTE': 'CDF Internal Notes',
+    'CDF-NOTE': 'CDF Notes',
+    'CDSHIDDEN': 'CDS Hidden',
+    'D0-INTERNAL-NOTE': 'D0 Internal Notes',
+    'D0-PRELIMINARY-NOTE': 'D0 Preliminary Notes',
+    'H1-INTERNAL-NOTE': 'H1 Internal Notes',
+    'H1-PRELIMINARY-NOTE': 'H1 Preliminary Notes',
+    'HALHIDDEN': 'HAL Hidden',
+    'HEPHIDDEN': 'HEP Hidden',
+    'HERMES-INTERNAL-NOTE': 'HERMES Internal Notes',
+    'LARSOFT-INTERNAL-NOTE': 'LArSoft Internal Notes',
+    'LARSOFT-NOTE': 'LArSoft Notes',
+    'ZEUS-INTERNAL-NOTE': 'ZEUS Internal Notes',
+    'ZEUS-PRELIMINARY-NOTE': 'ZEUS Preliminary Notes',
+}
+
+
 def add_arxiv_categories(record, blob):
     if not record.get('arxiv_eprints') or not blob.get('65017'):
         return record
@@ -61,6 +82,14 @@ def add_inspire_categories(record, blob):
     return record
 
 
+def copy_special_collections(record, blob):
+    if record.get('special_collections'):
+        record.setdefault('_collections', []).extend(
+            _normalize_special_collection(el) for el in record['special_collections'])
+
+    return record
+
+
 def ensure_document_type(record, blob):
     if not record.get('document_type'):
         record['document_type'] = ['article']
@@ -75,10 +104,15 @@ def ensure_hep(record, blob):
     return record
 
 
+def _normalize_special_collection(special_collection):
+    return SPECIAL_COLLECTIONS_MAP.get(special_collection)
+
+
 hep_filters = [
     add_schema('hep.json'),
     add_arxiv_categories,
     add_inspire_categories,
+    copy_special_collections,
     ensure_document_type,
     clean_record,
 ]

--- a/tests/test_hep_bd9xx.py
+++ b/tests/test_hep_bd9xx.py
@@ -254,7 +254,6 @@ def test_special_collections_from_980__a():
 
     assert validate(result['special_collections'], subschema) is None
     assert expected == result['special_collections']
-    assert '_collections' not in result
 
     expected = [
         {'a': 'HALHIDDEN'},
@@ -281,7 +280,6 @@ def test_special_collections_from_980__a_babar_analysis_document():
 
     assert validate(result['special_collections'], subschema) is None
     assert expected == result['special_collections']
-    assert '_collections' not in result
 
     expected = [
         {'a': 'BABAR-AnalysisDocument'},
@@ -308,7 +306,10 @@ def test_collections_and_special_collections_from_980__a():
     )  # record/1201407
 
     expected = {
-        '_collections': ['Literature'],
+        '_collections': [
+            'Literature',
+            'D0 Preliminary Notes',
+        ],
         'special_collections': ['D0-PRELIMINARY-NOTE'],
     }
     result = hep.do(create_record(snippet))

--- a/tests/test_hep_model.py
+++ b/tests/test_hep_model.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspire_dojson.hep.model import SPECIAL_COLLECTIONS_MAP
+from inspire_schemas.api import load_schema
+
+
+def test_special_collections_map_contains_all_valid_special_collections():
+    schema = load_schema('hep')
+    subschema = schema['properties']['special_collections']
+
+    expected = subschema['items']['enum']
+    result = SPECIAL_COLLECTIONS_MAP.keys()
+
+    assert sorted(expected) == sorted(result)


### PR DESCRIPTION
When migrating thousands of records the receiver in invenio-collections
is too slow for practical use. Given that its job is simply to copy
(and normalize) the value of `special_collections` in `_collections`,
we can simply do this work in DoJSON and detach the receiver during
migration (as suggested by @jmartinm).