### PR TITLE
hepnames2marc: use _collections, not a filter

### DIFF
--- a/inspire_dojson/hepnames/model.py
+++ b/inspire_dojson/hepnames/model.py
@@ -27,12 +27,6 @@ from __future__ import absolute_import, division, print_function
 from ..model import FilterOverdo, add_schema, add_collection, clean_record
 
 
-def ensure_hepnames(record, blob):
-    record.setdefault('980', []).append({'a': 'HEPNAMES'})
-
-    return record
-
-
 hepnames_filters = [
     add_schema('authors.json'),
     add_collection('Authors'),
@@ -40,7 +34,6 @@ hepnames_filters = [
 ]
 
 hepnames2marc_filters = [
-    ensure_hepnames,
     clean_record,
 ]
 

--- a/inspire_dojson/hepnames/rules.py
+++ b/inspire_dojson/hepnames/rules.py
@@ -554,6 +554,13 @@ def deleted(self, key, value):
     return deleted
 
 
+@hepnames2marc.over('980', '^_collections$')
+@utils.for_each_value
+def _collections2marc(self, key, value):
+    if value == 'Authors':
+        return {'a': 'HEPNAMES'}
+
+
 @hepnames2marc.over('980', '^deleted$')
 @utils.for_each_value
 def deleted2marc(self, key, value):

--- a/tests/test_hepnames.py
+++ b/tests/test_hepnames.py
@@ -1437,7 +1437,10 @@ def test_stub_from_980__a_useful():
     ]
     result = hepnames2marc.do(result)
 
-    assert expected == result['980']
+    for el in expected:
+        assert el in result['980']
+    for el in result['980']:
+        assert el in expected
 
 
 def test_stub_from_980__a_not_useful():
@@ -1486,4 +1489,7 @@ def test_deleted_from_980__c():
     ]
     result = hepnames2marc.do(result)
 
-    assert expected == result['980']
+    for el in expected:
+        assert el in result['980']
+    for el in result['980']:
+        assert el in expected


### PR DESCRIPTION
Now that we can assume that a record in the Authors collection has
a `_collections` field we can convert that instead of using a post
processing filter.