### PR TITLE
travis: use the container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@
 notifications:
   email: false
 
+sudo: false
+
 language: python
 
 cache: pip


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments the boot time is one order of magnitude less.