### PR TITLE
hep: move incomplete publication_infos

### DIFF
--- a/inspire_dojson/hep/model.py
+++ b/inspire_dojson/hep/model.py
@@ -48,6 +48,22 @@ def add_arxiv_categories(record, blob):
     return record
 
 
+def move_incomplete_publication_infos(record, blob):
+    def _keys_with_truthy_values(d):
+        return [k for k, v in d.items() if v]
+
+    if not record.get('publication_info'):
+        return record
+
+    for publication_info in record['publication_info']:
+        if _keys_with_truthy_values(publication_info) == ['journal_title']:
+            public_note = {'value': 'Submitted to {}'.format(publication_info['journal_title'])}
+            record.setdefault('public_notes', []).append(public_note)
+            del publication_info['journal_title']
+
+    return record
+
+
 def ensure_document_type(record, blob):
     if not record.get('document_type'):
         record['document_type'] = ['article']
@@ -128,6 +144,7 @@ def write_ids(record, blob):
 hep_filters = [
     add_schema('hep.json'),
     add_arxiv_categories,
+    move_incomplete_publication_infos,
     ensure_curated,
     ensure_document_type,
     ensure_unique_documents_and_figures,

--- a/tests/test_hep_bd7xx.py
+++ b/tests/test_hep_bd7xx.py
@@ -490,6 +490,26 @@ def test_publication_info_from_773__c_z_handles_dashes_in_isbns():
     assert expected == result['773']
 
 
+def test_publication_info_from_773__p_populates_public_notes():
+    schema = load_schema('hep')
+    subschema = schema['properties']['public_notes']
+
+    snippet = (
+        '<datafield tag="773" ind1=" " ind2=" ">'
+        '  <subfield code="p">Phys.Rev.D</subfield>'
+        '</datafield>'
+    )  # record/1631620
+
+    expected = [
+        {'value': 'Submitted to Phys.Rev.D'},
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['public_notes'], subschema) is None
+    assert expected == result['public_notes']
+    assert 'publication_info' not in result
+
+
 def test_publication_info_from_7731_c_p_v_y():
     schema = load_schema('hep')
     subschema = schema['properties']['publication_info']


### PR DESCRIPTION
A ``publication_info`` that contains only a ``journal_title`` would
like to represent that we know that this paper was submitted to that
journal, but not yet published.

Unfortunately this is inferred from clues like the formatting of the
PDF, not known, and is not later updated if the paper is rejected or
published.

This makes searching on this field more difficult, as it generates
false positives that have to be filtered out at search time.

Therefore this commit moves these values to ``public_notes``.