### PR TITLE
global: add the unicode-string-literal dependency

### DIFF
--- a/inspire_dojson/hep/model.py
+++ b/inspire_dojson/hep/model.py
@@ -57,7 +57,7 @@ def move_incomplete_publication_infos(record, blob):
 
     for publication_info in record['publication_info']:
         if _keys_with_truthy_values(publication_info) == ['journal_title']:
-            public_note = {'value': 'Submitted to {}'.format(publication_info['journal_title'])}
+            public_note = {'value': u'Submitted to {}'.format(publication_info['journal_title'])}
             record.setdefault('public_notes', []).append(public_note)
             del publication_info['journal_title']
 
@@ -113,7 +113,7 @@ def ensure_unique_documents_and_figures(record, blob):
                     duplicate_keys_list.append(element['key'])
 
     for index, attachment in itertools.chain(duplicates(record.get('documents', [])), duplicates(record.get('figures', []))):
-        attachment['key'] = '{}_{}'.format(index, attachment['key'])
+        attachment['key'] = u'{}_{}'.format(index, attachment['key'])
 
     return record
 

--- a/inspire_dojson/hep/rules/bd5xx.py
+++ b/inspire_dojson/hep/rules/bd5xx.py
@@ -154,7 +154,7 @@ def thesis_info2marc(self, key, value):
 
     if value.get('defense_date'):
         result_500.append({
-            'a': 'Presented on {}'.format(value.get('defense_date')),
+            'a': u'Presented on {}'.format(value.get('defense_date')),
         })
 
     result_502 = {

--- a/inspire_dojson/hep/rules/bd7xx.py
+++ b/inspire_dojson/hep/rules/bd7xx.py
@@ -126,9 +126,9 @@ def publication_info2marc(self, key, values):
     for value in force_list(values):
         page_artid = []
         if value.get('page_start') and value.get('page_end'):
-            page_artid.append('{page_start}-{page_end}'.format(**value))
+            page_artid.append(u'{page_start}-{page_end}'.format(**value))
         elif value.get('page_start'):
-            page_artid.append('{page_start}'.format(**value))
+            page_artid.append(u'{page_start}'.format(**value))
         if value.get('artid'):
             page_artid.append(u'{artid}'.format(**value))
 

--- a/inspire_dojson/utils/__init__.py
+++ b/inspire_dojson/utils/__init__.py
@@ -96,7 +96,7 @@ def absolute_url(relative_url):
     default_server = 'http://inspirehep.net'
     server = current_app.config.get('SERVER_NAME', default_server)
     if not re.match('^https?://', server):
-        server = 'http://{}'.format(server)
+        server = u'http://{}'.format(server)
     return urllib.parse.urljoin(server, relative_url)
 
 
@@ -125,7 +125,7 @@ def get_record_ref(recid, endpoint='record'):
     """
     if recid is None:
         return None
-    return {'$ref': absolute_url('/api/{}/{}'.format(endpoint, recid))}
+    return {'$ref': absolute_url(u'/api/{}/{}'.format(endpoint, recid))}
 
 
 def legacy_export_as_marc(json, tabsize=4):

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ tests_require = [
 extras_require = {
     'docs': docs_require,
     'tests': tests_require,
+    'tests:python_version=="2.7"': [
+        'unicode-string-literal~=1.0,>=1.1',
+    ],
 }
 
 extras_require['all'] = []


### PR DESCRIPTION
Prevents errors like the one fixed in f3de0554 from happening by
adding the ``unicode-string-literal`` dependency, which adds an
extra Flake8 check for Unicode-unsafe constructs.