### PR TITLE
hep2marc: correctly convert pre-2007 arXiv IDs

### DIFF
--- a/inspire_dojson/hep/rules/bd0xx.py
+++ b/inspire_dojson/hep/rules/bd0xx.py
@@ -31,7 +31,7 @@ import pycountry
 from isbn import ISBN
 
 from dojson import utils
-from idutils import is_doi, is_handle, normalize_doi
+from idutils import is_arxiv_post_2007, is_doi, is_handle, normalize_doi
 
 from inspire_schemas.api import load_schema
 from inspire_schemas.utils import normalize_arxiv_category
@@ -348,7 +348,7 @@ def arxiv_eprints(self, key, value):
 
 
 @hep2marc.over('037', '^arxiv_eprints$')
-def arxiv_eprints2marc(self, key, value):
+def arxiv_eprints2marc(self, key, values):
     """Populate the ``037`` MARC field.
 
     Also populates the ``035`` and the ``65017`` MARC fields through side effects.
@@ -357,11 +357,12 @@ def arxiv_eprints2marc(self, key, value):
     result_035 = self.get('035', [])
     result_65017 = self.get('65017', [])
 
-    values = force_list(value)
     for value in values:
+        arxiv_id = value.get('value')
+        arxiv_id = 'arXiv:' + arxiv_id if is_arxiv_post_2007(arxiv_id) else arxiv_id
         result_037.append({
             '9': 'arXiv',
-            'a': 'arXiv:' + value.get('value'),
+            'a': arxiv_id,
             'c': force_single_element(value.get('categories')),
         })
 

--- a/tests/test_hep_bd0xx.py
+++ b/tests/test_hep_bd0xx.py
@@ -874,6 +874,43 @@ def test_arxiv_eprints_from_037__a_c_9():
     assert expected == result['037']
 
 
+def test_arxiv_eprints_from_037__a_c_9_old_identifier():
+    schema = load_schema('hep')
+    subschema = schema['properties']['arxiv_eprints']
+
+    snippet = (
+        '<datafield tag="037" ind1=" " ind2=" ">'
+        '  <subfield code="a">hep-th/0110148</subfield>'
+        '  <subfield code="9">arXiv</subfield>'
+        '  <subfield code="c">hep-th</subfield>'
+        '</datafield>'
+    )  # record/782187
+
+    expected = [
+        {
+            'categories': [
+                'hep-th',
+            ],
+            'value': 'hep-th/0110148',
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['arxiv_eprints'], subschema) is None
+    assert expected == result['arxiv_eprints']
+
+    expected = [
+        {
+            '9': 'arXiv',
+            'a': 'hep-th/0110148',
+            'c': 'hep-th',
+        },
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['037']
+
+
 def test_arxiv_eprints_from_037__a_c_9_obsolete_category():
     schema = load_schema('hep')
     subschema = schema['properties']['arxiv_eprints']
@@ -902,7 +939,7 @@ def test_arxiv_eprints_from_037__a_c_9_obsolete_category():
     expected = [
         {
             '9': 'arXiv',
-            'a': 'arXiv:funct-an/9710003',
+            'a': 'funct-an/9710003',
             'c': 'math.FA',
         },
     ]


### PR DESCRIPTION
@ksachs @tsgit indeed, the problem was in dojson, not in the metadata on labs.