### PR TITLE
common: don't produce /api/record

### DIFF
--- a/inspire_dojson/common/rules.py
+++ b/inspire_dojson/common/rules.py
@@ -582,21 +582,26 @@ WEBLINKS = {
 }
 
 
-def self_url(index):
-    def _self_url(self, key, value):
-        self['control_number'] = int(value)
-        return get_record_ref(value, index)
-    return _self_url
+def control_number(endpoint):
+    """Populate the ``control_number`` key.
+
+    Also populates the ``self`` key through side effects.
+    """
+    def _control_number(self, key, value):
+        self['self'] = get_record_ref(int(value), endpoint)
+        return int(value)
+
+    return _control_number
 
 
-conferences.over('self', '^001')(self_url('conferences'))
-data.over('self', '^001')(self_url('data'))
-experiments.over('self', '^001')(self_url('experiments'))
-hep.over('self', '^001')(self_url('literature'))
-hepnames.over('self', '^001')(self_url('authors'))
-institutions.over('self', '^001')(self_url('institutions'))
-jobs.over('self', '^001')(self_url('jobs'))
-journals.over('self', '^001')(self_url('journals'))
+conferences.over('control_number', '^001')(control_number('conferences'))
+data.over('control_number', '^001')(control_number('data'))
+experiments.over('control_number', '^001')(control_number('experiments'))
+hep.over('control_number', '^001')(control_number('literature'))
+hepnames.over('control_number', '^001')(control_number('authors'))
+institutions.over('control_number', '^001')(control_number('institutions'))
+jobs.over('control_number', '^001')(control_number('jobs'))
+journals.over('control_number', '^001')(control_number('journals'))
 
 
 @hep2marc.over('001', '^control_number$')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -254,7 +254,7 @@ def test_new_record_from_970__d():
         '</datafield>'
     )  # record/37545
 
-    expected = {'$ref': 'http://localhost:5000/api/record/361769'}
+    expected = {'$ref': 'http://localhost:5000/api/literature/361769'}
     result = hep.do(create_record(snippet))
 
     assert validate(result['new_record'], subschema) is None
@@ -276,7 +276,7 @@ def test_deleted_records_from_981__a():
         '</datafield>'
     )  # record/1508886
 
-    expected = [{'$ref': 'http://localhost:5000/api/record/1508668'}]
+    expected = [{'$ref': 'http://localhost:5000/api/literature/1508668'}]
     result = hep.do(create_record(snippet))
 
     assert validate(result['deleted_records'], subschema) is None


### PR DESCRIPTION
Second commit fixed the bug we noticed the other day (but we should still fix the wrong redirect in `inspire-next`). First commit makes things more uniform.