### PR TITLE
travis: avoid caching the pytest-flake8 cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ language: python
 
 cache:
   pip: true
-  directories:
-    - .cache
 
 python:
   - 2.7


### PR DESCRIPTION
  Reverts 71c56ce because the timestamp of the last modification
is always going to be after the timestamp saved by pytest-flake8,
since Travis clones a fresh copy of the repository each time it
makes a new build.