### PR TITLE
global: better handle FFT URLs

### DIFF
--- a/inspire_dojson/hep/rules/bdFFT.py
+++ b/inspire_dojson/hep/rules/bdFFT.py
@@ -82,7 +82,7 @@ def documents(self, key, value):
         figures.append({
             'key': _get_key(value),
             'caption': caption,
-            'url': afs_url(value),
+            'url': afs_url(value.get('a')),
             'order': index
         })
         self['figures'] = figures
@@ -92,7 +92,7 @@ def documents(self, key, value):
             'key': _get_key(value),
             'fulltext': _is_fulltext(value),
             'hidden': _is_hidden(force_list(value.get('o'))),
-            'url': afs_url(value),
+            'url': afs_url(value.get('a')),
             'source': _get_source(value),
         }
 

--- a/inspire_dojson/utils/__init__.py
+++ b/inspire_dojson/utils/__init__.py
@@ -108,20 +108,22 @@ def absolute_url(relative_url):
     return urllib.parse.urljoin(server, relative_url)
 
 
-def afs_url(value):
-    """Returns the AFS absolute path from the FFT ``path`` key.
+def afs_url(file_path):
+    """Convert a file path to a URL pointing to its path on AFS.
 
-    If ``path`` doesn't start with ``/opt/cds-invenio/`` it returns it unchanged.
+    If ``file_path`` doesn't start with ``/opt/cds-invenio/``, and hence is not on
+    AFS, it returns it unchanged.
     """
     default_afs_path = '/afs/cern.ch/project/inspire/PROD'
-    file_path = value.get('a')
 
     if file_path is None:
         return
 
     if file_path.startswith('/opt/cds-invenio/'):
         file_path = os.path.relpath(file_path, '/opt/cds-invenio/')
-        return os.path.join(default_afs_path, file_path)
+        file_path = os.path.join(default_afs_path, file_path)
+        return urllib.parse.urljoin('file://', urllib.request.pathname2url(file_path))
+
     return file_path
 
 

--- a/inspire_dojson/utils/__init__.py
+++ b/inspire_dojson/utils/__init__.py
@@ -113,15 +113,19 @@ def afs_url(file_path):
 
     If ``file_path`` doesn't start with ``/opt/cds-invenio/``, and hence is not on
     AFS, it returns it unchanged.
+
+    The base AFS path is taken from the Flask app config if present, otherwise
+    it falls back to ``/afs/cern.ch/project/inspire/PROD``.
     """
     default_afs_path = '/afs/cern.ch/project/inspire/PROD'
+    afs_path = current_app.config.get('LEGACY_AFS_PATH', default_afs_path)
 
     if file_path is None:
         return
 
     if file_path.startswith('/opt/cds-invenio/'):
         file_path = os.path.relpath(file_path, '/opt/cds-invenio/')
-        file_path = os.path.join(default_afs_path, file_path)
+        file_path = os.path.join(afs_path, file_path)
         return urllib.parse.urljoin('file://', urllib.request.pathname2url(file_path))
 
     return file_path

--- a/tests/test_hep_bdFFT.py
+++ b/tests/test_hep_bdFFT.py
@@ -49,7 +49,7 @@ def test_documents_from_FFT():
     expected = [
         {
             'key': 'arXiv:1710.01187.pdf',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf%3B1',
         },
     ]
     result = hep.do(create_record(snippet))
@@ -93,11 +93,11 @@ def test_documents_are_unique_from_FFT():
     expected = [
         {
             'key': 'arXiv:1710.01187.pdf',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf%3B1',
         },
         {
             'key': '1_arXiv:1710.01187.pdf',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf%3B1',
         },
     ]
     result = hep.do(create_record(snippet))
@@ -129,7 +129,7 @@ def test_figures_from_FFT():
         {
             'key': 'FIG10.png',
             'caption': 'Co-simulation results, at $50~\mathrm{ms}$...',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037399/content.png;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037399/content.png%3B1',
         },
     ]
     result = hep.do(create_record(snippet))
@@ -185,17 +185,17 @@ def test_figures_order_from_FFT():
         {
             'key': 'FIG10.png',
             'caption': 'Co-simulation results, at $50~\mathrm{ms}$...',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037399/content.png;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037399/content.png%3B1',
         },
         {
             'key': 'FIG11.png',
             'caption': 'Co-simulation results, at $50~\mathrm{ms}$...',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037400/content.png;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037400/content.png%3B1',
         },
         {
             'key': 'FIG12.png',
             'caption': 'Co-simulation results, at $50~\mathrm{ms}$...',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037401/content.png;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037401/content.png%3B1',
         }
     ]
     result = hep.do(create_record(snippet))
@@ -342,6 +342,48 @@ def test_figures_to_FFT():
     assert expected == result['FFT']
 
 
+def test_figure_from_FFT_generates_valid_uri():
+    schema = load_schema('hep')
+    subschema = schema['properties']['figures']
+
+    snippet = (
+        '<datafield tag="FFT" ind1=" " ind2=" ">'
+        '  <subfield code="a">/opt/cds-invenio/var/data/files/g83/1678426/FKLP new_VF.png;1</subfield>'
+        '  <subfield code="d">00000 Inflationary potential ${g^{2}\\vp^{2}\\over 2} (1-a\\vp+b\\vp^{2})^2$  (\\ref{three}), for $a = 0.1$, $b = 0.0035$. The field is shown in Planck units, the potential $V$ is shown in units $g^{2}$. In realistic models of that type, $g \\sim 10^{-5} - 10^{-6}$ in Planck units, depending on details of the theory, so the height of the potential in this figure is about $10^{-10}$ in Planck units.</subfield>'
+        '  <subfield code="f">.png</subfield>'
+        '  <subfield code="n">FKLP new_VF</subfield>'
+        '  <subfield code="r"></subfield>'
+        '  <subfield code="s">2013-10-22 05:04:33</subfield>'
+        '  <subfield code="t">Plot</subfield>'
+        '  <subfield code="v">1</subfield>'
+        '  <subfield code="z"></subfield>'
+        '</datafield>'
+    )  # record/1245001
+
+    expected = [
+        {
+            'key': 'FKLP new_VF.png',
+            'caption': 'Inflationary potential ${g^{2}\\vp^{2}\\over 2} (1-a\\vp+b\\vp^{2})^2$  (\\ref{three}), for $a = 0.1$, $b = 0.0035$. The field is shown in Planck units, the potential $V$ is shown in units $g^{2}$. In realistic models of that type, $g \\sim 10^{-5} - 10^{-6}$ in Planck units, depending on details of the theory, so the height of the potential in this figure is about $10^{-10}$ in Planck units.',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g83/1678426/FKLP%20new_VF.png%3B1',
+        }
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['figures'], subschema) is None
+    assert expected == result['figures']
+
+    expected = [
+        {
+            'a': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g83/1678426/FKLP%20new_VF.png%3B1',
+            'd': '00000 Inflationary potential ${g^{2}\\vp^{2}\\over 2} (1-a\\vp+b\\vp^{2})^2$  (\\ref{three}), for $a = 0.1$, $b = 0.0035$. The field is shown in Planck units, the potential $V$ is shown in units $g^{2}$. In realistic models of that type, $g \\sim 10^{-5} - 10^{-6}$ in Planck units, depending on details of the theory, so the height of the potential in this figure is about $10^{-10}$ in Planck units.',
+            't': 'Plot',
+        }
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['FFT']
+
+
 def test_figures_and_documents_from_FFT_without_d_subfield():
     schema = load_schema('hep')
     figures_subschema = schema['properties']['figures']
@@ -375,14 +417,14 @@ def test_figures_and_documents_from_FFT_without_d_subfield():
     expected_figures = [
         {
             'key': 'FIG10.png',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037399/content.png;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037399/content.png%3B1',
         },
     ]
 
     expected_documents = [
         {
             'key': 'arXiv:1710.01187.pdf',
-            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf;1',
+            'url': 'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf%3B1',
         },
     ]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,7 @@ from mock import patch
 
 from inspire_dojson.utils import (
     absolute_url,
+    afs_url,
     normalize_rank,
     force_single_element,
     get_recid_from_ref,
@@ -134,6 +135,34 @@ def test_absolute_url_with_https_server_name():
         result = absolute_url('foo')
 
         assert expected == result
+
+
+def test_afs_url_ignores_non_afs_path():
+    expected = 'http://example.com/file.pdf'
+    result = afs_url('http://example.com/file.pdf')
+
+    assert expected == result
+
+
+def test_afs_url_converts_afs_path():
+    expected = 'file:///afs/cern.ch/project/inspire/PROD/var/file.txt'
+    result = afs_url('/opt/cds-invenio/var/file.txt')
+
+    assert expected == result
+
+
+def test_afs_url_encodes_characters():
+    expected = 'file:///afs/cern.ch/project/inspire/PROD/var/file%20with%20spaces.txt'
+    result = afs_url('/opt/cds-invenio/var/file with spaces.txt')
+
+    assert expected == result
+
+
+def test_afs_url_handles_none():
+    expected = None
+    result = afs_url(None)
+
+    assert expected == result
 
 
 def test_get_record_ref_with_empty_server_name():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -165,6 +165,16 @@ def test_afs_url_handles_none():
     assert expected == result
 
 
+def test_afs_url_with_custom_afs_path():
+    config = {'LEGACY_AFS_PATH': '/custom/path/'}
+
+    with patch.dict(current_app.config, config):
+        expected = 'file:///custom/path/var/file.txt'
+        result = afs_url('/opt/cds-invenio/var/file.txt')
+
+        assert expected == result
+
+
 def test_get_record_ref_with_empty_server_name():
     config = {}
 


### PR DESCRIPTION
* transforms paths to proper `file://` URLs, including escaping.
* makes the AFS base URL configurable through the Flask config.
