### PR TITLE
utils: handle unicode in afs_url

### DIFF
--- a/inspire_dojson/utils/__init__.py
+++ b/inspire_dojson/utils/__init__.py
@@ -126,7 +126,7 @@ def afs_url(file_path):
     if file_path.startswith('/opt/cds-invenio/'):
         file_path = os.path.relpath(file_path, '/opt/cds-invenio/')
         file_path = os.path.join(afs_path, file_path)
-        return urllib.parse.urljoin('file://', urllib.request.pathname2url(file_path))
+        return urllib.parse.urljoin('file://', urllib.request.pathname2url(file_path.encode('utf-8')))
 
     return file_path
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,6 +175,13 @@ def test_afs_url_with_custom_afs_path():
         assert expected == result
 
 
+def test_afs_url_handles_unicode():
+    expected = u'file:///afs/cern.ch/project/inspire/PROD/var/data/files/g70/1407585/%E7%89%A9%E7%90%86%E7%A7%91%E5%AD%A6%E4%B8%8E%E6%8A%80%E6%9C%AF%E5%AD%A6%E9%99%A2-%E6%9D%8E%E5%A8%9C-200650218-%E5%AD%A6%E4%BD%8D%E7%BA%A7....pdf%3B1'
+    result = afs_url(u'/opt/cds-invenio/var/data/files/g70/1407585/物理科学与技术学院-李娜-200650218-学位级....pdf;1')
+
+    assert expected == result
+
+
 def test_get_record_ref_with_empty_server_name():
     config = {}
 


### PR DESCRIPTION
This requires to encode/decode to utf-8 as `urllib.request.pathname2url`
doesn't handle unicode strings.