### PR TITLE
global: don't use pytest-flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   - travis_retry pip install -e .[tests]
 
 script:
-  - py.test inspire_dojson tests
+  - ./run-tests.sh
 
 after_success:
   - coveralls

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,15 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-#
-# Tests
-#
+set -e
 
-[coverage:run]
-include = inspire_dojson/*.py
-
-[tool:pytest]
-addopts = --cov=inspire_dojson --cov-report=term-missing:skip-covered
-
-[flake8]
-ignore = *.py E501 FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53
+flake8 inspire_dojson tests
+py.test tests

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ tests_require = [
     'mock~=2.0,>=2.0.0',
     'pytest~=3.0,>=3.1.2',
     'pytest-cov~=2.0,>=2.5.1',
-    'pytest-flake8~=0.0,>=0.8.1',
 ]
 
 extras_require = {

--- a/tests/test_cds.py
+++ b/tests/test_cds.py
@@ -1194,13 +1194,13 @@ def test_documents_from_8564_s_u_y_8():
     )  # cds.cern.ch/record/2294664
 
     expected = [
-            {
-                't': 'CDS',
-                'a': 'http://cds.cern.ch/record/2294664/files/James.pdf',
-                'd': 'Fulltext',
-                'n': 'James.pdf',
-                'f': '.pdf',
-            },
+        {
+            't': 'CDS',
+            'a': 'http://cds.cern.ch/record/2294664/files/James.pdf',
+            'd': 'Fulltext',
+            'n': 'James.pdf',
+            'f': '.pdf',
+        },
     ]
     result = cds2hep_marc.do(create_record(snippet))
 
@@ -1208,12 +1208,12 @@ def test_documents_from_8564_s_u_y_8():
 
     expected = [
         {
-                'key': 'James.pdf',
-                'fulltext': True,
-                'source': 'CDS',
-                'url': 'http://cds.cern.ch/record/2294664/files/James.pdf',
-            },
-        ]
+            'key': 'James.pdf',
+            'fulltext': True,
+            'source': 'CDS',
+            'url': 'http://cds.cern.ch/record/2294664/files/James.pdf',
+        },
+    ]
     result = hep.do(create_record_from_dict(result))
 
     assert validate(result['documents'], subschema) is None

--- a/tests/test_hep_bd9xx.py
+++ b/tests/test_hep_bd9xx.py
@@ -1340,7 +1340,7 @@ def test_references_from_999C5k():
         {
             'k': 'Robilotta:2008js',
             'z': 0,
-         },
+        },
     ]
     result = hep2marc.do(result)
 


### PR DESCRIPTION
Remove ``pytest-flake8`` and replace it with just ``flake8`` as the
former is sometimes not finding style violations present in the code.