### PR TITLE
data: migrate dois field

### DIFF
--- a/inspire_dojson/data/rules.py
+++ b/inspire_dojson/data/rules.py
@@ -24,8 +24,20 @@
 
 from __future__ import absolute_import, division, print_function
 
+from dojson import utils
+from idutils import normalize_doi
+
 from .model import data
 from ..utils import force_single_element, get_record_ref
+
+
+@data.over('dois', '^0247.')
+@utils.for_each_value
+def dois(self, key, value):
+    return {
+        'source': value.get('9'),
+        'value': normalize_doi(value.get('a')),
+    }
 
 
 @data.over('new_record', '^970..')

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     'Flask~=0.0,>=0.12.2',
     'IDUtils~=0.0,>=0.2.4',
     'dojson~=1.0,>=1.3.1',
-    'inspire-schemas~=57.0,>=57.0.0',
+    'inspire-schemas~=57.0,>=57.1.0',
     'inspire-utils~=2.0,>=2.0.0',
     'isbnid_fork~=0.0,>=0.5.2',
     'langdetect~=1.0,>=1.0.7',

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -28,6 +28,28 @@ from inspire_dojson.data import data
 from inspire_schemas.api import load_schema, validate
 
 
+def test_dois_from_0247_2_a():
+    schema = load_schema('data')
+    subschema = schema['properties']['dois']
+
+    snippet = (
+        '<datafield tag="024" ind1="7" ind2=" ">'
+        '  <subfield code="a">10.17182/hepdata.77268.v1/t6</subfield>'
+        '  <subfield code="2">DOI</subfield>'
+        '</datafield>'
+    )  # record/1639676
+
+    expected = [
+        {
+            'value': '10.17182/hepdata.77268.v1/t6',
+        }
+    ]
+    result = data.do(create_record(snippet))
+
+    assert validate(result['dois'], subschema) is None
+    assert expected == result['dois']
+
+
 def test_new_record_from_970__d():
     schema = load_schema('data')
     subschema = schema['properties']['new_record']


### PR DESCRIPTION
Tested locally, only 1 record fails because it has a HDL instead of a DOI: http://inspirehep.net/record/1244560.