### PR TITLE
tests: add more tests to marcxml2record

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,6 +27,19 @@ import pytest
 from inspire_dojson.api import marcxml2record, record2marcxml
 
 
+def test_marcxml2record_handles_conferences():
+    snippet = (
+        '<datafield tag="980" ind1=" " ind2=" ">'
+        '  <subfield code="a">CONFERENCES</subfield>'
+        '</datafield>'
+    )
+
+    expected = 'conferences.json'
+    result = marcxml2record(snippet)
+
+    assert expected == result['$schema']
+
+
 def test_marcxml2record_handles_data():
     snippet = (
         '<datafield tag="980" ind1=" " ind2=" ">'
@@ -40,6 +53,32 @@ def test_marcxml2record_handles_data():
     assert expected == result['$schema']
 
 
+def test_marcxml2record_handles_experiments():
+    snippet = (
+        '<datafield tag="980" ind1=" " ind2=" ">'
+        '  <subfield code="a">EXPERIMENT</subfield>'
+        '</datafield>'
+    )
+
+    expected = 'experiments.json'
+    result = marcxml2record(snippet)
+
+    assert expected == result['$schema']
+
+
+def test_marcxml2record_handles_hepnames():
+    snippet = (
+        '<datafield tag="980" ind1=" " ind2=" ">'
+        '  <subfield code="a">HEPNAMES</subfield>'
+        '</datafield>'
+    )
+
+    expected = 'authors.json'
+    result = marcxml2record(snippet)
+
+    assert expected == result['$schema']
+
+
 def test_marcxml2record_handles_institutions():
     snippet = (
         '<datafield tag="980" ind1=" " ind2=" ">'
@@ -48,6 +87,45 @@ def test_marcxml2record_handles_institutions():
     )
 
     expected = 'institutions.json'
+    result = marcxml2record(snippet)
+
+    assert expected == result['$schema']
+
+
+def test_marcxml2record_handles_jobs():
+    snippet = (
+        '<datafield tag="980" ind1=" " ind2=" ">'
+        '  <subfield code="a">JOB</subfield>'
+        '</datafield>'
+    )
+
+    expected = 'jobs.json'
+    result = marcxml2record(snippet)
+
+    assert expected == result['$schema']
+
+
+def test_marcxml2record_handles_jobhidden():
+    snippet = (
+        '<datafield tag="980" ind1=" " ind2=" ">'
+        '  <subfield code="a">JOBHIDDEN</subfield>'
+        '</datafield>'
+    )
+
+    expected = 'jobs.json'
+    result = marcxml2record(snippet)
+
+    assert expected == result['$schema']
+
+
+def test_marcxml2record_handles_journals():
+    snippet = (
+        '<datafield tag="980" ind1=" " ind2=" ">'
+        '  <subfield code="a">JOURNALS</subfield>'
+        '</datafield>'
+    )
+
+    expected = 'journals.json'
     result = marcxml2record(snippet)
 
     assert expected == result['$schema']


### PR DESCRIPTION
I was a little paranoid that we still had a bug like the ones fixed in https://github.com/inspirehep/inspire-dojson/commit/29804a9986b85e2c8fa6f76d6fa9f613884d67b4 or https://github.com/inspirehep/inspire-dojson/commit/9b207573c87972b35474ff84ab14db9dde229a30.