### PR TITLE
698 model: make exceptions more user-friendly

### DIFF
--- a/inspire_dojson/errors.py
+++ b/inspire_dojson/errors.py
@@ -20,10 +20,20 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""INSPIRE DoJSON rules."""
+"""Custom errors for INSPIRE DoJSON."""
 
 from __future__ import absolute_import, division, print_function
 
-from . import common  # noqa: F401
-from .api import marcxml2record, record2marcxml  # noqa: F401
-from .errors import DoJsonError  # noqa: F401
+from six import python_2_unicode_compatible, text_type
+
+
+@python_2_unicode_compatible
+class DoJsonError(Exception):
+    """Error during DoJSON processing."""
+    def __str__(self):
+        message = self.args[0]
+        exc = u' '.join(text_type(arg) for arg in self.args[1])
+        subfields = [(k, v) for (k, v) in self.args[2].items() if k != '__order__']
+        return u'{message}\n\n{exc}\n\nSubfields: {subfields}'.format(
+            message=message, exc=exc, subfields=subfields
+        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -22,7 +22,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
 from inspire_dojson.model import FilterOverdo, add_schema
+from inspire_dojson import DoJsonError, marcxml2record
 
 
 def test_filteroverdo_works_without_filters():
@@ -32,6 +35,23 @@ def test_filteroverdo_works_without_filters():
     result = model.do({})
 
     assert expected == result
+
+
+def test_filteroverdo_wraps_exceptions():
+    record = (
+        '<record>'
+        '  <datafield tag="269" ind1=" " ind2=" ">'
+        '    <subfield code="c">Ceci n’est pas une dâte</subfield>'
+        '  </datafield>'
+        '  <datafield tag="980" ind1=" " ind2=" ">'
+        '    <subfield code="a">HEP</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # synthetic data
+
+    with pytest.raises(DoJsonError) as exc:
+        marcxml2record(record)
+    assert 'Error in rule "preprint_date" for field "269__"' in str(exc.value)
 
 
 def test_add_schema():


### PR DESCRIPTION
This intercepts errors happening inside dojson in order to present them in a more user friendly way:

```
In [1]: from inspire_dojson import marcxml2record

In [2]: marcxml2record('''<record>
   ...: <datafield tag="980" ind1=" " ind2=" ">
   ...: <subfield code="a">HEP</subfield>
   ...: </datafield>
   ...: <datafield tag="269" ind1=" " ind2=" ">
   ...: <subfield code="c">Foo</subfield>
   ...: </datafield>
   ...: </record>''')
ERROR:root:An unexpected error occurred while tokenizing input
The following traceback may be corrupted or invalid
The error message is: ('EOF in multi-line string', (1, 9))

---------------------------------------------------------------------------
DoJsonError                               Traceback (most recent call last)
<ipython-input-2-1d0482f17771> in <module>()
      6 <subfield code="c">Foo</subfield>
      7 </datafield>
----> 8 </record>''')

/home/micha/src/inspire-dojson/inspire_dojson/api.pyc in marcxml2record(marcxml)
     98     elif 'journals' in collections or 'journalsnew' in collections:
     99         return journals.do(marcjson)
--> 100     return hep.do(marcjson)
    101 
    102 

/home/micha/src/inspire-dojson/inspire_dojson/model.py in do(self, blob, **kwargs)
     44 
     45     def do(self, blob, **kwargs):
---> 46         result = super(FilterOverdo, self).do(blob, **kwargs)
     47 
     48         for filter_ in self.filters:

/home/micha/.virtualenvs/inspire-dojson/local/lib/python2.7/site-packages/dojson/overdo.pyc in do(self, blob, ignore_missing, exception_handlers)
    147 
    148                 name, creator = result
--> 149                 data = creator(output, key, value)
    150                 if getattr(creator, '__extend__', False):
    151                     existing = output.get(name, [])

/home/micha/src/inspire-dojson/inspire_dojson/model.py in func(self, key, value)
     66                     raise exc
     67                 raise DoJsonError(
---> 68                     u'Error in rule "{name}" for field "{key}"'.format(name=name, key=key), exc.args, value
     69                 )
     70 

DoJsonError: Error in rule "preprint_date" for field "269__"

Unknown string format: Foo

Subfields: [('c', 'Foo')]

```