### PR TITLE
hep: ignore 773__x if marked as done

### DIFF
--- a/inspire_dojson/hep/rules/bd7xx.py
+++ b/inspire_dojson/hep/rules/bd7xx.py
@@ -95,6 +95,11 @@ def publication_info(self, key, value):
         if z_value:
             return normalize_isbn(z_value)
 
+    def _get_pubinfo_freetext(value):
+        x_value = force_single_element(value.get('x', ''))
+        if not x_value.startswith('#DONE'):
+            return x_value
+
     page_start, page_end, artid = split_page_artid(value.get('c'))
 
     parent_recid = maybe_int(force_single_element(value.get('0')))
@@ -122,7 +127,7 @@ def publication_info(self, key, value):
         'parent_isbn': _get_parent_isbn(value),
         'parent_record': parent_record,
         'parent_report_number': force_single_element(value.get('r')),
-        'pubinfo_freetext': force_single_element(value.get('x')),
+        'pubinfo_freetext': _get_pubinfo_freetext(value),
         'year': maybe_int(force_single_element(value.get('y'))),
     }
 

--- a/tests/test_hep_bd7xx.py
+++ b/tests/test_hep_bd7xx.py
@@ -654,6 +654,49 @@ def test_publication_info_from_double_773__p():
     assert expected == result['public_notes']
 
 
+def test_publication_info_from_773__c_p_v_x_y_1_discards_done_x():
+    schema = load_schema('hep')
+    subschema = schema['properties']['publication_info']
+
+    snippet = (
+        '<datafield tag="773" ind1=" " ind2=" ">'
+        '  <subfield code="c">134516</subfield>'
+        '  <subfield code="p">Phys.Rev.</subfield>'
+        '  <subfield code="v">B93</subfield>'
+        '  <subfield code="x">#DONE: Phys. Rev. B 93, 134516 (2016)</subfield>'
+        '  <subfield code="y">2016</subfield>'
+        '  <subfield code="1">1214516</subfield>'
+        '</datafield>'
+    )  # record/1479030
+
+    expected = [
+        {
+            'artid': '134516',
+            'journal_title': 'Phys.Rev.B',
+            'journal_volume': '93',
+            'year': 2016,
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['publication_info'], subschema) is None
+    assert expected == result['publication_info']
+
+    expected = [
+        {
+            'c': [
+                '134516',
+            ],
+            'p': 'Phys.Rev.',
+            'v': 'B93',
+            'y': 2016,
+        },
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['773']
+
+
 def test_publication_info_from_7731_c_p_v_y():
     schema = load_schema('hep')
     subschema = schema['properties']['publication_info']


### PR DESCRIPTION
This is the same as #205 which cannot be reopened because @jacquerie deleted his repo.

We want this in order to avoid having to deal with the ugly #DONE strings in the display formats, and if we ever need them we can go back to the MARC source.