### PR TITLE
global: make dedupe selective

### DIFF
--- a/inspire_dojson/cds/model.py
+++ b/inspire_dojson/cds/model.py
@@ -76,7 +76,7 @@ filters = [
     add_control_number,
     add_collections,
     remove_english_language,
-    clean_record,
+    clean_record(),
 ]
 
 cds2hep_marc = FilterOverdo(filters=filters)

--- a/inspire_dojson/conferences/model.py
+++ b/inspire_dojson/conferences/model.py
@@ -40,7 +40,7 @@ filters = [
     add_schema('conferences.json'),
     add_collection('Conferences'),
     remove_lone_series_number,
-    clean_record,
+    clean_record(),
 ]
 
 conferences = FilterOverdo(filters=filters)

--- a/inspire_dojson/data/model.py
+++ b/inspire_dojson/data/model.py
@@ -30,7 +30,7 @@ from ..model import FilterOverdo, add_schema, add_collection, clean_record
 filters = [
     add_schema('data.json'),
     add_collection('Data'),
-    clean_record,
+    clean_record(),
 ]
 
 data = FilterOverdo(filters=filters)

--- a/inspire_dojson/experiments/model.py
+++ b/inspire_dojson/experiments/model.py
@@ -38,7 +38,7 @@ filters = [
     add_schema('experiments.json'),
     add_collection('Experiments'),
     add_project_type,
-    clean_record,
+    clean_record(),
 ]
 
 experiments = FilterOverdo(filters=filters)

--- a/inspire_dojson/hep/model.py
+++ b/inspire_dojson/hep/model.py
@@ -36,7 +36,7 @@ from inspire_schemas.builders.literature import is_citeable
 from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
 
-from ..model import FilterOverdo, add_schema, clean_record
+from ..model import FilterOverdo, add_schema, clean_marc, clean_record
 
 
 def add_arxiv_categories(record, blob):
@@ -193,13 +193,13 @@ hep_filters = [
     ensure_unique_documents_and_figures,
     ensure_ordered_figures,
     set_citeable,
-    clean_record,
+    clean_record(exclude_keys={'authors'}),
 ]
 
 hep2marc_filters = [
     write_ids,
     convert_curated,
-    clean_record,
+    clean_marc,
 ]
 
 hep = FilterOverdo(filters=hep_filters)

--- a/inspire_dojson/hep/rules/bd7xx.py
+++ b/inspire_dojson/hep/rules/bd7xx.py
@@ -147,7 +147,7 @@ def publication_info2marc(self, key, values):
             page_artid.append(u'{page_start}-{page_end}'.format(**value))
         elif value.get('page_start'):
             page_artid.append(u'{page_start}'.format(**value))
-        if value.get('artid'):
+        elif value.get('artid'):
             page_artid.append(u'{artid}'.format(**value))
 
         result = {

--- a/inspire_dojson/hepnames/model.py
+++ b/inspire_dojson/hepnames/model.py
@@ -24,17 +24,17 @@
 
 from __future__ import absolute_import, division, print_function
 
-from ..model import FilterOverdo, add_schema, add_collection, clean_record
+from ..model import FilterOverdo, add_schema, add_collection, clean_marc, clean_record
 
 
 hepnames_filters = [
     add_schema('authors.json'),
     add_collection('Authors'),
-    clean_record,
+    clean_record(),
 ]
 
 hepnames2marc_filters = [
-    clean_record,
+    clean_marc,
 ]
 
 hepnames = FilterOverdo(filters=hepnames_filters)

--- a/inspire_dojson/institutions/model.py
+++ b/inspire_dojson/institutions/model.py
@@ -42,7 +42,7 @@ filters = [
     add_schema('institutions.json'),
     add_collection('Institutions'),
     combine_addresses_and_location,
-    clean_record,
+    clean_record(),
 ]
 
 institutions = FilterOverdo(filters=filters)

--- a/inspire_dojson/jobs/model.py
+++ b/inspire_dojson/jobs/model.py
@@ -30,7 +30,7 @@ from ..model import FilterOverdo, add_schema, add_collection, clean_record
 filters = [
     add_schema('jobs.json'),
     add_collection('Jobs'),
-    clean_record,
+    clean_record(),
 ]
 
 jobs = FilterOverdo(filters=filters)

--- a/inspire_dojson/journals/model.py
+++ b/inspire_dojson/journals/model.py
@@ -30,7 +30,7 @@ from ..model import FilterOverdo, add_collection, add_schema, clean_record
 filters = [
     add_schema('journals.json'),
     add_collection('Journals'),
-    clean_record,
+    clean_record(),
 ]
 
 journals = FilterOverdo(filters=filters)

--- a/inspire_dojson/model.py
+++ b/inspire_dojson/model.py
@@ -91,5 +91,11 @@ def add_collection(name):
     return _add_collection
 
 
-def clean_record(record, blob):
-    return dedupe_all_lists(strip_empty_values(record))
+def clean_marc(record, blob):
+    return strip_empty_values(record)
+
+
+def clean_record(exclude_keys=()):
+    def _clean_record(record, blob):
+        return dedupe_all_lists(strip_empty_values(record), exclude_keys=exclude_keys)
+    return _clean_record

--- a/inspire_dojson/utils/__init__.py
+++ b/inspire_dojson/utils/__init__.py
@@ -164,13 +164,21 @@ def strip_empty_values(obj):
         return None
 
 
-def dedupe_all_lists(obj):
-    """Recursively remove duplucates from all lists."""
+def dedupe_all_lists(obj, exclude_keys=()):
+    """Recursively remove duplucates from all lists.
+
+    Args:
+        obj: collection to deduplicate
+        exclude_keys (Container[str]): key names to ignore for deduplication
+    """
     squared_dedupe_len = 10
     if isinstance(obj, dict):
         new_obj = {}
         for key, value in obj.items():
-            new_obj[key] = dedupe_all_lists(value)
+            if key in exclude_keys:
+                new_obj[key] = value
+            else:
+                new_obj[key] = dedupe_all_lists(value)
         return new_obj
     elif isinstance(obj, (list, tuple, set)):
         new_elements = [dedupe_all_lists(v) for v in obj]

--- a/tests/test_hep_bd1xx.py
+++ b/tests/test_hep_bd1xx.py
@@ -1704,6 +1704,74 @@ def test_authors_from_700__a_double_e_handles_multiple_roles():
     assert expected == result['authors']
 
 
+def test_authors_from_700__a_w_x_y_repeated_author():
+    schema = load_schema('hep')
+    subschema = schema['properties']['authors']
+
+    snippet = (
+        '<record>'
+        '  <datafield tag="700" ind1=" " ind2=" ">'
+        '    <subfield code="a">Suzuki, K.</subfield>'
+        '    <subfield code="w">Ken.Suzuki.1</subfield>'
+        '    <subfield code="x">1458204</subfield>'
+        '    <subfield code="y">0</subfield>'
+        '  </datafield>'
+        '  <datafield tag="700" ind1=" " ind2=" ">'
+        '    <subfield code="a">Suzuki, K.</subfield>'
+        '    <subfield code="w">Ken.Suzuki.1</subfield>'
+        '    <subfield code="x">1458204</subfield>'
+        '    <subfield code="y">0</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1684644
+
+    expected = [
+        {
+            'full_name': 'Suzuki, K.',
+            'ids': [
+                {
+                    'schema': 'INSPIRE BAI',
+                    'value': 'Ken.Suzuki.1',
+                },
+            ],
+            'record': {
+                '$ref': 'http://localhost:5000/api/authors/1458204',
+            },
+        },
+        {
+            'full_name': 'Suzuki, K.',
+            'ids': [
+                {
+                    'schema': 'INSPIRE BAI',
+                    'value': 'Ken.Suzuki.1',
+                },
+            ],
+            'record': {
+                '$ref': 'http://localhost:5000/api/authors/1458204',
+            },
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['authors'], subschema) is None
+    assert expected == result['authors']
+
+    expected = {
+        '100': {
+            'a': 'Suzuki, K.',
+        },
+        '700': [
+            {
+                'a': 'Suzuki, K.',
+            },
+        ],
+    }
+    result = hep2marc.do(result)
+
+    assert expected['100'] == result['100']
+    assert expected['700'] == result['700']
+
+
 def test_corporate_author_from_110__a():
     schema = load_schema('hep')
     subschema = schema['properties']['corporate_author']


### PR DESCRIPTION
Previously, all lists were being deduped. This is wrong for `authors` that
are allowed to be repeated, and in `record2marcxml` as the json records should be
clean already. This fixes the issue by not deduping in those cases.