### PR TITLE
hep: deduplicate author affiliations

### DIFF
--- a/inspire_dojson/hep/rules/bd1xx.py
+++ b/inspire_dojson/hep/rules/bd1xx.py
@@ -28,6 +28,7 @@ import re
 
 from dojson import utils
 
+from inspire_utils.dedupers import dedupe_list
 from inspire_utils.helpers import force_list, maybe_int
 
 from ..model import hep, hep2marc
@@ -59,7 +60,7 @@ def _authors(key, value):
             for u_value in u_values:
                 result.append({'value': u_value})
 
-        return result
+        return dedupe_list(result)
 
     def _get_curated_relation(value):
         return value.get('y') == '1' or None

--- a/tests/test_hep_bd1xx.py
+++ b/tests/test_hep_bd1xx.py
@@ -1796,3 +1796,67 @@ def test_corporate_author_from_110__a():
     result = hep2marc.do(result)
 
     assert expected == result['110']
+
+
+def test_authors_from_100__a_with_q_w_y_z_duplicated_u():
+    schema = load_schema('hep')
+    subschema = schema['properties']['authors']
+
+    snippet = (
+        '<datafield tag="100" ind1=" " ind2=" ">'
+        '  <subfield code="a">Dineykhan, M.</subfield>'
+        '  <subfield code="q">Dineĭkhan, M.</subfield>'
+        '  <subfield code="q">Dineikhan, M.</subfield>'
+        '  <subfield code="q">Динейхан, М.</subfield>'
+        '  <subfield code="u">Dubna, JINR</subfield>'
+        '  <subfield code="u">Dubna, JINR</subfield>'
+        '  <subfield code="w">M.Dineykhan.1</subfield>'
+        '  <subfield code="y">0</subfield>'
+        '  <subfield code="z">902780</subfield>'
+        '  <subfield code="z">902780</subfield>'
+        '</datafield>'
+    )  # record/144579
+
+    expected = [
+        {
+            'affiliations': [
+                {
+                    'record': {
+                        '$ref': 'http://localhost:5000/api/institutions/902780',
+                    },
+                    'value': 'Dubna, JINR',
+                },
+            ],
+            'alternative_names': [
+                u'Dineĭkhan, M.',
+                u'Dineikhan, M.',
+                u'Динейхан, М.',
+            ],
+            'full_name': 'Dineykhan, M.',
+            'ids': [
+                {
+                    'schema': 'INSPIRE BAI',
+                    'value': 'M.Dineykhan.1',
+                },
+            ],
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['authors'], subschema) is None
+    assert expected == result['authors']
+
+    expected = {
+        'a': 'Dineykhan, M.',
+        'q': [
+            u'Dineĭkhan, M.',
+            u'Dineikhan, M.',
+            u'Динейхан, М.',
+        ],
+        'u': [
+            'Dubna, JINR',
+        ],
+    }
+    result = hep2marc.do(result)
+
+    assert expected == result['100']


### PR DESCRIPTION
When removing the deduplication of authors, we inadvertently removed
the deduplication of the author affiliations.

Signed-off-by: David Caro <david@dcaro.es>