### PR TITLE
hep: FFT without t subfield

### DIFF
--- a/inspire_dojson/hep/rules/bdFFT.py
+++ b/inspire_dojson/hep/rules/bdFFT.py
@@ -66,7 +66,7 @@ def documents(self, key, value):
         return fname + extension
 
     def _get_source(value):
-        source = value.get('t')
+        source = value.get('t', '')
         if source in ('INSPIRE-PUBLIC', 'Main'):
             source = None
         elif source.lower() == 'arxiv':

--- a/tests/test_hep_bdFFT.py
+++ b/tests/test_hep_bdFFT.py
@@ -544,3 +544,28 @@ def test_figures2marc_handles_unicode():
     result = hep2marc.do(record)
 
     assert expected == result['FFT']
+
+
+def test_documents_from_FFT_without_t_subfield():
+    schema = load_schema('hep')
+    subschema = schema['properties']['documents']
+
+    snippet = (
+        "<datafield tag='FFT' ind1=' ' ind2=' '>"
+        "  <subfield code='a'>http://scoap3.iop.org/article/doi/10.1088/1674-1137/43/1/013104?format=pdf</subfield>"
+        "  <subfield code='f'>.pdf</subfield>"
+        "  <subfield code='n'>fulltext</subfield>"
+        "</datafield>"
+    )
+
+    expected = [
+        {
+            'url': 'http://scoap3.iop.org/article/doi/10.1088/1674-1137/43/1/013104?format=pdf',
+            'key': 'fulltext.pdf'
+        }
+
+    ]
+    result = hep.do(create_record(snippet))
+    assert validate(result['documents'], subschema) is None
+    assert expected == result['documents']
+    assert 'figures' not in result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -320,4 +320,4 @@ def test_normalize_date_aggressively_raises_on_wrong_format():
 
 
 def test_normalize_date_aggressively_ignores_fake_dates():
-        assert normalize_date_aggressively('0000') is None
+    assert normalize_date_aggressively('0000') is None


### PR DESCRIPTION
In case an `FFT` field doesn't contain a `t` subfield, the `lower` function will be called on `None`. Added empty string as default to prevent this.