### PR TITLE
Remove flask version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Flask~=0.0,>=0.12.3',
+    'Flask>=0.12.3, <2.0.0',
     'IDUtils~=1.0,>=1.0.1',
     'dojson~=1.0,>=1.3.1',
     'inspire-schemas~=59.0,>=59.0.5',


### PR DESCRIPTION
INSPIR-643 Remove flask version restriction so that we can use flask 1 on inspirehep and old flask version on inspire-next