### PR TITLE
utils: fix setting of default_server

### DIFF
--- a/inspire_dojson/utils/__init__.py
+++ b/inspire_dojson/utils/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014-2017 CERN.
+# Copyright (C) 2014-2019 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -102,7 +102,9 @@ def absolute_url(relative_url):
     falls back to ``http://inspirehep.net``.
     """
     default_server = 'http://inspirehep.net'
-    server = current_app.config.get('SERVER_NAME', default_server)
+    server = current_app.config.get('SERVER_NAME')
+    if server is None:
+        server = default_server
     if not re.match('^https?://', server):
         server = u'http://{}'.format(server)
     return urllib.parse.urljoin(server, relative_url)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014-2017 CERN.
+# Copyright (C) 2014-2019 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -101,6 +101,16 @@ def test_absolute_url_with_empty_server_name():
     config = {}
 
     with patch.dict(current_app.config, config, clear=True):
+        expected = 'http://inspirehep.net/foo'
+        result = absolute_url('foo')
+
+        assert expected == result
+
+
+def test_absolute_url_with_undef_server_name():
+    config = {'SERVER_NAME': None}
+
+    with patch.dict(current_app.config, config, clear=False):
         expected = 'http://inspirehep.net/foo'
         result = absolute_url('foo')
 


### PR DESCRIPTION

`SERVER_NAME` is a always present as a key in `app.app_context()`, but initialized to `None`. Therefore the usual way to define a default does not apply. This patch sets default_server as intended if no SERVER_NAME is defined in the app context.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>