### PR TITLE
hep: correctly set citeable for publication_info

### DIFF
--- a/inspire_dojson/hep/model.py
+++ b/inspire_dojson/hep/model.py
@@ -192,8 +192,8 @@ hep_filters = [
     ensure_document_type,
     ensure_unique_documents_and_figures,
     ensure_ordered_figures,
-    set_citeable,
     clean_record(exclude_keys={'authors'}),
+    set_citeable,  # XXX has to happen after clean_record as is_citeable doesn't check if values are not-None
 ]
 
 hep2marc_filters = [

--- a/tests/test_hep_model.py
+++ b/tests/test_hep_model.py
@@ -59,3 +59,37 @@ def test_ensure_curated_when_500_present():
 
     assert validate(result['curated'], subschema) is None
     assert expected == result['curated']
+
+
+def test_set_citeable_when_not_citeable():
+    snippet = (
+        '<datafield tag="773" ind1=" " ind2=" ">'
+        '  <subfield code="c">152-61</subfield>'
+        '  <subfield code="x">Proc. of Athens Topical Conference on Recently Discovered Resonant Particles, Athens, Ohio, 1963. Athens, Ohio, Ohio U., 1963. p. 152-61</subfield>'
+        '</datafield>'
+    )  # record/59
+
+    result = hep.do(create_record(snippet))
+
+    assert 'citeable' not in result
+
+
+def test_set_citeable_when_citeable():
+    schema = load_schema('hep')
+    subschema = schema['properties']['citeable']
+
+    snippet = (
+        '<datafield tag="773" ind1=" " ind2=" ">'
+        '  <subfield code="p">Nucl.Phys.</subfield>'
+        '  <subfield code="v">22</subfield>'
+        '  <subfield code="c">579-588</subfield>'
+        '  <subfield code="y">1961</subfield>'
+        '  <subfield code="1">1214548</subfield>'
+        '</datafield>'
+    )  # record/4328
+
+    expected = True
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['citeable'], subschema) is None
+    assert expected == result['citeable']


### PR DESCRIPTION
`set_citeable` uses the `is_citeable` function from the
`inspire_schemas` literature builder. That function checks for the
existence of some keys in the `publication_info` to determine whether
the record is citeable. However, all keys in the `publication_info` are
always populated, but the value is `None` in case no value is provided.
This makes `is_citeable` always return true if there is any
`publication_info`.

The solution is to call it after `clean_record` that
strips off keys with `None` values.

Signed-off-by: Micha Moskovic <michamos@gmail.com>