### PR TITLE
utils: respect PREFERRED_URL_SCHEME

### DIFF
--- a/inspire_dojson/utils/__init__.py
+++ b/inspire_dojson/utils/__init__.py
@@ -102,11 +102,10 @@ def absolute_url(relative_url):
     falls back to ``http://inspirehep.net``.
     """
     default_server = 'http://inspirehep.net'
-    server = current_app.config.get('SERVER_NAME')
-    if server is None:
-        server = default_server
+    server = current_app.config['SERVER_NAME'] or default_server
+    scheme = current_app.config['PREFERRED_URL_SCHEME']
     if not re.match('^https?://', server):
-        server = u'http://{}'.format(server)
+        server = u'{scheme}://{server}'.format(scheme=scheme, server=server)
     return urllib.parse.urljoin(server, relative_url)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,20 +97,10 @@ def test_force_single_element_returns_none_on_empty_list():
     assert force_single_element([]) is None
 
 
-def test_absolute_url_with_empty_server_name():
-    config = {}
-
-    with patch.dict(current_app.config, config, clear=True):
-        expected = 'http://inspirehep.net/foo'
-        result = absolute_url('foo')
-
-        assert expected == result
-
-
 def test_absolute_url_with_undef_server_name():
     config = {'SERVER_NAME': None}
 
-    with patch.dict(current_app.config, config, clear=False):
+    with patch.dict(current_app.config, config):
         expected = 'http://inspirehep.net/foo'
         result = absolute_url('foo')
 
@@ -142,6 +132,16 @@ def test_absolute_url_with_https_server_name():
 
     with patch.dict(current_app.config, config):
         expected = 'https://example.com/foo'
+        result = absolute_url('foo')
+
+        assert expected == result
+
+
+def test_absolute_url_with_https_preferred_scheme():
+    config = {'PREFERRED_URL_SCHEME': 'https'}
+
+    with patch.dict(current_app.config, config):
+        expected = 'https://localhost:5000/foo'
         result = absolute_url('foo')
 
         assert expected == result
@@ -193,9 +193,9 @@ def test_afs_url_handles_unicode():
 
 
 def test_get_record_ref_with_empty_server_name():
-    config = {}
+    config = {'SERVER_NAME': None}
 
-    with patch.dict(current_app.config, config, clear=True):
+    with patch.dict(current_app.config, config):
         expected = 'http://inspirehep.net/api/endpoint/123'
         result = get_record_ref(123, 'endpoint')
 
@@ -237,9 +237,9 @@ def test_get_record_ref_without_recid_returns_none():
 
 
 def test_get_record_ref_without_endpoint_defaults_to_record():
-    config = {}
+    config = {'SERVER_NAME': None}
 
-    with patch.dict(current_app.config, config, clear=True):
+    with patch.dict(current_app.config, config):
         expected = 'http://inspirehep.net/api/record/123'
         result = get_record_ref(123)
 


### PR DESCRIPTION
* In `absolute_url`, the `PREFERRED_URL_SCHEME` Flask config variable is
  now used to determine the scheme to use when making absolute URLs out
  of relative ones. This should have the effect of using `https` for
  URLs to files in production, avoid unnecessary redirects, and hence
  make @tsgit happy.

Signed-off-by: Micha Moskovic <michamos@gmail.com>